### PR TITLE
Set node env vm global and vm window object

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,7 +33,7 @@ const options = {
         plugins: ['transform-runtime']
     },
     dom: true,
-    html: '<div class="box">example</div>'
+    html: '<div class="box">example</div>',
     vm: {
         filename: <string>,
         lineOffset: <number>,
@@ -67,6 +67,17 @@ const ctx = exportContext.run('TARGET/FILE/PATH.js', options);
 
 // clear sandbox dom settings
 exportContext.clear()
+```
+
+
+If the environment variable ```NODE_ENV``` is specified,
+it is reflected in the global variable and window object
+
+```js
+// set process.env.NODE_ENV = 'test'
+
+global.NODE_ENV // => test
+window.NODE_ENV // => test
 ```
 
 ## API

--- a/index.js
+++ b/index.js
@@ -63,6 +63,10 @@ var ExportContext = function () {
       __dirname: __dirname
     };
 
+    if (process.env.NODE_ENV) {
+      this.initSandbox.NODE_ENV = process.env.NODE_ENV;
+    }
+
     this.sandbox = this.initSandbox;
     this.cleanup = null;
     this.filePath = null;
@@ -78,6 +82,11 @@ var ExportContext = function () {
     this.createGlobalDom = function () {
       var __global = _lodash2.default.cloneDeep(global);
       _this.cleanup = (0, _jsdomGlobal2.default)();
+
+      if (process.env.NODE_ENV) {
+        global.window.NODE_ENV = process.env.NODE_ENV;
+      }
+
       var sandbox = Object.assign({}, {
         document: global.document,
         window: global.window

--- a/package.json
+++ b/package.json
@@ -58,5 +58,10 @@
     "rules": {
       "no-native-reassign": "warn"
     }
+  },
+  "nyc": {
+    "exclude": [
+      "example/**/*.js"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "xo src/*.js",
     "pretest": "npm set progress=false && npm i jquery --cache-min 86400 && npm run lint && npm run build",
-    "test": "nyc ava test/*.js",
+    "test": "NODE_ENV=test nyc ava test/*.js",
     "build": "babel --debug --presets latest -o index.js src/index.js"
   },
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,10 @@ class ExportContext {
       __dirname
     };
 
+    if (process.env.NODE_ENV) {
+      this.initSandbox.NODE_ENV = process.env.NODE_ENV;
+    }
+
     this.sandbox = this.initSandbox;
     this.cleanup = null;
     this.filePath = null;
@@ -34,6 +38,11 @@ class ExportContext {
     this.createGlobalDom = () => {
       const __global = _.cloneDeep(global);
       this.cleanup = jsdom();
+
+      if (process.env.NODE_ENV) {
+        global.window.NODE_ENV = process.env.NODE_ENV;
+      }
+
       const sandbox = Object.assign({}, {
         document: global.document,
         window: global.window

--- a/test/test.js
+++ b/test/test.js
@@ -10,10 +10,15 @@ import ExportContext from '../index.js';
 
 const fn = new ExportContext;
 
+test('constructor', t => {
+    t.is(fn.sandbox.NODE_ENV, 'test');
+});
+
 test('createGlobalDom', t => {
     const res = fn.createGlobalDom();
     t.is(typeof res.document, 'object');
     t.is(typeof res.window, 'object');
+    t.is(res.window.NODE_ENV, 'test');
 });
 
 test('projectRoot', t => {
@@ -72,7 +77,6 @@ test('runContext', t => {
     const context = fn.runContext({code: 'var test = true;', sandbox: {}, option: option});
     t.is(context.test, true);
     t.true(spy.calledOnce);
-    console.log(spy.args[0])
     t.is(spy.args[0][2].filename, option.filename);
    spy.restore();
 });


### PR DESCRIPTION
If the environment variable ```NODE_ENV``` is specified,
it is reflected in the global variable and window object

```js
// set process.env.NODE_ENV = 'test'

global.NODE_ENV // => test
window.NODE_ENV // => test
```

and more.

- nyc exclude file option set