### PR TITLE
Make the requested module a property of the window object

### DIFF
--- a/index.js
+++ b/index.js
@@ -260,6 +260,9 @@ var ExportContext = function () {
 
       Object.keys(modules).forEach(function (key) {
         sandbox[key] = require(modules[key]);
+        if (sandbox.window) {
+          sandbox.window[key] = require(modules[key]);
+        }
       });
 
       return sandbox;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "export-context",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Get the methods that are not exports as context. these methods becomes possible operations, such as unit testing",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -200,6 +200,9 @@ class ExportContext {
   addModules(modules = {}, sandbox = {}) {
     Object.keys(modules).forEach(key => {
       sandbox[key] = require(modules[key]);
+      if (sandbox.window) {
+        sandbox.window[key] = require(modules[key]);
+      }
     });
 
     return sandbox;

--- a/test/test.js
+++ b/test/test.js
@@ -89,6 +89,11 @@ test('addModules', t => {
     let res = fn.addModules(modules, sandbox);
 
     t.is(res.$, expected.$);
+
+    sandbox.window = {};
+    res = fn.addModules(modules, sandbox);
+
+    t.is(expected.$, res.window.$);
 });
 
 test('addHtml', t => {


### PR DESCRIPTION
If there is a window object in the sandbox,
Make the requested module a property of the window object.

And bump up v.0.0.7

```js
(function(global) {
if (!global) {
  global = window
}

var $ = global.jQuery // <--- undefined is now

}).call(null, this)

